### PR TITLE
LPD-21217   Implement disabling sorting control

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/java/com/liferay/frontend/data/set/views/web/internal/portlet/action/SaveFDSFieldsMVCResourceCommand.java
@@ -84,7 +84,9 @@ public class SaveFDSFieldsMVCResourceCommand
 				).put(
 					"renderer", "default"
 				).put(
-					"sortable", true
+					"sortable",
+					Boolean.valueOf(
+						String.valueOf(creationDataJSONObject.get("sortable")))
 				).put(
 					"type", String.valueOf(creationDataJSONObject.get("type"))
 				).build(),

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/api.ts
@@ -12,7 +12,13 @@ import {fetch} from 'frontend-js-web';
 import {FDSViewType} from './FDSViews';
 import {OBJECT_RELATIONSHIP} from './utils/constants';
 import openDefaultFailureToast from './utils/openDefaultFailureToast';
-import {EFieldFormat, EFieldType, IField, IPickList} from './utils/types';
+import {
+	EFieldFormat,
+	EFieldType,
+	IFDSField,
+	IField,
+	IPickList,
+} from './utils/types';
 
 const INVALID_FIELDS = ['actions', 'scopeKey', 'x-class-name', 'x-schema-name'];
 
@@ -146,4 +152,10 @@ export async function getAllPicklists(
 	}
 
 	return items;
+}
+
+export function isSortable(field: IFDSField | IField): boolean {
+	return !(
+		field.type === EFieldType.OBJECT || field.type === EFieldType.ARRAY
+	);
 }

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/src/main/resources/META-INF/resources/js/fds_view/visualization_modes/table/Table.tsx
@@ -23,7 +23,7 @@ import React, {useEffect, useState} from 'react';
 
 import {IFDSViewSectionProps} from '../../../FDSView';
 import {FDSViewType} from '../../../FDSViews';
-import {getFields} from '../../../api';
+import {getFields, isSortable} from '../../../api';
 import AutoSearch from '../../../components/AutoSearch';
 import OrderableTable from '../../../components/OrderableTable';
 import SearchResultsMessage from '../../../components/SearchResultsMessage';
@@ -161,13 +161,18 @@ const SaveFDSFieldsModalContent = ({
 	const saveFDSFields = async () => {
 		setSaveButtonDisabled(true);
 
-		const creationData: Array<{name: string; type: string}> = [];
+		const creationData: Array<{
+			name: string;
+			sortable: boolean;
+			type: string;
+		}> = [];
 		const deletionIds: Array<number> = [];
 
 		fields?.forEach((field) => {
 			if (field.selected && !field.id) {
 				creationData.push({
 					name: field.name,
+					sortable: isSortable(field),
 					type: field.type || 'string',
 				});
 			}
@@ -433,8 +438,11 @@ const EditFDSFieldModalContent = ({
 	const [selectedFDSFieldRenderer, setSelectedFDSFieldRenderer] = useState(
 		fdsField.renderer ?? 'default'
 	);
+
+	const isSortableField = isSortable(fdsField);
+
 	const [fdsFieldSortable, setFSDFieldSortable] = useState<boolean>(
-		fdsField.sortable ?? true
+		fdsField.sortable ?? isSortableField
 	);
 
 	const fdsInternalCellRendererNames = FDS_INTERNAL_CELL_RENDERERS.map(
@@ -615,6 +623,7 @@ const EditFDSFieldModalContent = ({
 				<ClayForm.Group>
 					<ClayCheckbox
 						checked={fdsFieldSortable}
+						disabled={!isSortableField}
 						inline
 						label={Liferay.Language.get('sortable')}
 						onChange={({target: {checked}}) =>
@@ -622,14 +631,16 @@ const EditFDSFieldModalContent = ({
 						}
 					/>
 
-					<span
-						className="label-icon lfr-portal-tooltip ml-2"
-						title={Liferay.Language.get(
-							'if-checked,-data-set-items-can-be-sorted-by-this-field'
-						)}
-					>
-						<ClayIcon symbol="question-circle-full" />
-					</span>
+					{isSortableField && (
+						<span
+							className="label-icon lfr-portal-tooltip ml-2"
+							title={Liferay.Language.get(
+								'if-checked,-data-set-items-can-be-sorted-by-this-field'
+							)}
+						>
+							<ClayIcon symbol="question-circle-full" />
+						</span>
+					)}
 				</ClayForm.Group>
 			</ClayModal.Body>
 

--- a/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/api.d.ts
+++ b/modules/apps/frontend-data-set/frontend-data-set-views-web/types/src/main/resources/META-INF/resources/js/api.d.ts
@@ -4,9 +4,10 @@
  */
 
 import {FDSViewType} from './FDSViews';
-import {IField, IPickList} from './utils/types';
+import {IFDSField, IField, IPickList} from './utils/types';
 export declare function getFields(fdsView: FDSViewType): Promise<IField[]>;
 export declare function getAllPicklists(
 	page?: number,
 	items?: IPickList[]
 ): Promise<IPickList[]>;
+export declare function isSortable(field: IFDSField | IField): boolean;


### PR DESCRIPTION
Hey @kresimir-coko this is the idea I had in mind for this story, pls consider using it as starting point.

To see it in action (and implement test) you can just pick the `/data-set-manager/fields` endpoint and use `FDSField` schema.

Then map parent and leave fields and see the difference in the checkbox